### PR TITLE
fix(repo): skip symlinks during status scan

### DIFF
--- a/pkg/repo/status.go
+++ b/pkg/repo/status.go
@@ -105,10 +105,13 @@ func (r *Repo) Status() ([]StatusEntry, error) {
 			return nil
 		}
 
-		// Only track regular files.
-		if !d.IsDir() {
-			workFiles[rel] = true
+		// Only track regular files. Staging refuses symlink targets, and a
+		// symlink that points at a directory would make the rename and
+		// content scans read a directory, so skip symlinks here.
+		if d.IsDir() || d.Type()&fs.ModeSymlink != 0 {
+			return nil
 		}
+		workFiles[rel] = true
 		return nil
 	})
 	if err != nil {

--- a/pkg/repo/status_test.go
+++ b/pkg/repo/status_test.go
@@ -940,3 +940,39 @@ func statusCacheSize(r *Repo) int {
 	defer r.statusHashCacheMu.Unlock()
 	return len(r.statusHashCache)
 }
+
+func TestStatus_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := r.Add([]string{"main.go"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "target"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "target", "data.txt"), []byte("data\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "dirlink")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "main.go"), filepath.Join(dir, "filelink")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	entries, err := r.Status()
+	if err != nil {
+		t.Fatalf("Status with symlinks: %v", err)
+	}
+	for _, e := range entries {
+		if e.Path == "dirlink" || e.Path == "filelink" {
+			t.Errorf("Status listed symlink %q; symlinks cannot be staged and must be skipped", e.Path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The status scan was treating any non-directory entry as a work file, including symlinks. Symlinks cannot be staged, and a symlink that points at a directory would cause subsequent rename and content scans to read a directory as if it were a file. This change makes Status skip symlinks entirely.

## Changes

- Skip symlinks during the status worktree scan by treating them the same as directories (returning early) rather than recording them as work files
- Add reason in the comment: staging refuses symlink targets, and a symlink pointing at a directory would cause the rename/content scans to treat it as a directory
- Add TestStatus_SkipsSymlinks covering both a directory symlink and a file symlink, with a skip fallback on platforms without symlink support

## Testing

- go test ./pkg/repo/ -run TestStatus_SkipsSymlinks